### PR TITLE
Fix final amount calculation for charges coupon

### DIFF
--- a/src/ChargeCoupon.php
+++ b/src/ChargeCoupon.php
@@ -60,7 +60,7 @@ class ChargeCoupon extends Model
         if ($this->amount_off !== null) {
             $amount = $amount - $this->amount_off;
         } elseif ($this->percent_off !== null) {
-            $amount = $amount * ($this->percent_off / 100);
+            $amount = $amount - ($amount * ($this->percent_off / 100));
         }
 
         $amount = (int) (round($amount));


### PR DESCRIPTION
The calculation was returning the discount amount instead of the final amount when using percentage.